### PR TITLE
#36 Example does not work in 2.6.x due to the security headers filter

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,1 +1,8 @@
 # https://www.playframework.com/documentation/latest/Configuration
+
+# https://www.playframework.com/documentation/latest/SecurityHeaders
+# Allow URLs from the same origin to be loaded by frames and scripts
+play.filters.headers {
+  frameOptions = "SAMEORIGIN"
+  contentSecurityPolicy = "connect-src 'self'"
+}


### PR DESCRIPTION
This is a quick fix for #36. Basically I'm allowing iframes from same origin and inlined scripts.

Other potential (and quick) solutions would be:
- disable the `SecurityHeadersFilter` completely:
`play.filters.disabled+=play.filters.headers.SecurityHeadersFilter`
- disable only the 2 problematic headers:
```
play.filters.headers {
  frameOptions = null
  contentSecurityPolicy = null
}
```

Please let me know if you have a better alternative.